### PR TITLE
wconfig: find config directory

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,7 @@
 import wavy.wconfig
 
 def test_load_default():
-    c = wavy.wconfig.load_or_default('/model_specs.yaml')
+    c = wavy.wconfig.load_or_default('model_specs.yaml')
 
     assert isinstance(c, dict)
     print(c)

--- a/tests/test_satmod.py
+++ b/tests/test_satmod.py
@@ -15,7 +15,7 @@ nproc = 1
 instr = 'altimeter'
 provider = 'cmems'
 
-satellite_dict = load_or_default('/satellite_specs.yaml')
+satellite_dict = load_or_default('satellite_specs.yaml')
 
 
 @pytest.mark.need_credentials

--- a/wavy/modelmod.py
+++ b/wavy/modelmod.py
@@ -302,8 +302,8 @@ def get_model(model=None,sdate=None,edate=None,date_incr=None,
 # ---------------------------------------------------------------------#
 
 # read yaml config files:
-model_dict = load_or_default('/model_specs.yaml')
-variable_info = load_or_default('/variable_info.yaml')
+model_dict = load_or_default('model_specs.yaml')
+variable_info = load_or_default('variable_info.yaml')
 
 class model_class():
 

--- a/wavy/ncmod.py
+++ b/wavy/ncmod.py
@@ -31,11 +31,11 @@ import time
 from wavy.wconfig import load_or_default
 
 # read yaml config files:
-model_dict = load_or_default('/model_specs.yaml')
-buoy_dict = load_or_default('/buoy_specs.yaml')
-station_dict = load_or_default('/station_specs.yaml')
-variable_info = load_or_default('/variable_info.yaml')
-d22_dict = load_or_default('/d22_var_dicts.yaml')
+model_dict = load_or_default('model_specs.yaml')
+buoy_dict = load_or_default('buoy_specs.yaml')
+station_dict = load_or_default('station_specs.yaml')
+variable_info = load_or_default('variable_info.yaml')
+d22_dict = load_or_default('d22_var_dicts.yaml')
 
 # --- global functions ------------------------------------------------#
 """

--- a/wavy/satmod.py
+++ b/wavy/satmod.py
@@ -48,11 +48,11 @@ from wavy.wconfig import load_or_default
 # ---------------------------------------------------------------------#
 
 # read yaml config files:
-region_dict = load_or_default('/region_specs.yaml')
-model_dict = load_or_default('/model_specs.yaml')
-satellite_dict = load_or_default('/satellite_specs.yaml')
-variable_info = load_or_default('/variable_info.yaml')
-#variable_info = load_or_default('config/variable_info.yaml')
+region_dict = load_or_default('region_specs.yaml')
+model_dict = load_or_default('model_specs.yaml')
+satellite_dict = load_or_default('satellite_specs.yaml')
+variable_info = load_or_default('variable_info.yaml')
+#variable_info = load_or_default('variable_info.yaml')
 
 # --- global functions ------------------------------------------------#
 

--- a/wavy/stationmod.py
+++ b/wavy/stationmod.py
@@ -42,10 +42,10 @@ from wavy.wconfig import load_or_default
 # ---------------------------------------------------------------------#
 
 # read yaml config files:
-buoy_dict = load_or_default('/buoy_specs.yaml')
-station_dict = load_or_default('/station_specs.yaml')
-variable_info = load_or_default('/variable_info.yaml')
-d22_dict = load_or_default('/d22_var_dicts.yaml')
+buoy_dict = load_or_default('buoy_specs.yaml')
+station_dict = load_or_default('station_specs.yaml')
+variable_info = load_or_default('variable_info.yaml')
+d22_dict = load_or_default('d22_var_dicts.yaml')
 # --- global functions ------------------------------------------------#
 
 # define flatten function for lists

--- a/wavy/superobmod.py
+++ b/wavy/superobmod.py
@@ -10,7 +10,7 @@ from wavy.utils import find_included_times, collocate_times
 from wavy.wconfig import load_or_default
 from wavy.utils import runmean_conv
 
-variable_info = load_or_default('/variable_info.yaml')
+variable_info = load_or_default('variable_info.yaml')
 
 def superobbing(varalias,vardict,superob=None,outlier_detection='gam',\
 missing_data='marginalize',date_incr=None,**kwargs):

--- a/wavy/wconfig.py
+++ b/wavy/wconfig.py
@@ -1,16 +1,40 @@
 import os
 import yaml
 import logging
+
 logger = logging.getLogger(__name__)
+import dotenv
+import xdg
+
+dotenv.load_dotenv()
+
+
+def __get_confdir__():
+    """
+    Configuration directory is specified through:
+
+    .env
+    WAVY_CONNFIG environment variable
+    XDG configuration directory (wavy)
+    """
+    c = os.getenv('WAVY_CONFIG', None)
+    if c is None:
+        c = os.path.join(xdg.xdg_config_home(), 'wavy')
+
+        if not os.path.exists(c):
+            c = None
+
+    logger.debug('config directory: %s' % c)
+    return c
 
 
 def load_or_default(name):
     """
     Load the YAML configuration file from the current directory or use default. The approach is threefold and shown in order:
-    1. check if env 'WAVY_CONFIG' is set
-    2. check if .env exists
-    3. check if a config folder exists using xdg
-    4. fall back to default files within the package
+
+    1. check if env 'WAVY_CONFIG' is set or specified in .env
+    2. check if a config folder exists using xdg
+    3. fall back to default files within the package
 
     e.g.:
 
@@ -20,23 +44,14 @@ def load_or_default(name):
 
     """
     logging.debug('attempting to load: %s..' % name)
-    # get envs for wavy
-    # 1. check if already in envs
-    confdir = os.getenv('WAVY_CONFIG')
-    # 2. if not check if envs are in .env
-    if confdir is None:
-        from dotenv import load_dotenv
-        load_dotenv()
-        confdir = os.getenv('WAVY_CONFIG')
-    # 3. user wide, xdg
-    import xdg
-    confdir = os.path.join(xdg.xdg_config_home(),'wavy')
+
+    confdir = __get_confdir__()
 
     try:
-        #with open(name, 'r') as s:
         if confdir is not None:
-            filestr = os.path.join(confdir,name)
-        else: filestr = name
+            filestr = os.path.join(confdir, name)
+        else:
+            raise FileNotFoundError()
         with open(filestr, 'r') as s:
             return yaml.safe_load(s)
 

--- a/wavy/wconfig.py
+++ b/wavy/wconfig.py
@@ -40,7 +40,7 @@ def load_or_default(name):
 
     .. code::
 
-        c = load_or_default('/model_specs.yaml')
+        c = load_or_default('model_specs.yaml')
 
     """
     logging.debug('attempting to load: %s..' % name)
@@ -58,6 +58,6 @@ def load_or_default(name):
     except FileNotFoundError:
         logging.debug('could not load from local directory, using default.')
         from pkg_resources import resource_stream
-        #return yaml.safe_load(resource_stream(__name__, name + '.default'))
-        return yaml.safe_load(resource_stream(__name__, 'config/' \
-                            +  name + '.default'))
+        return yaml.safe_load(
+            resource_stream(__name__,
+                            os.path.join('config', name + '.default')))


### PR DESCRIPTION
once dotenv.load_dotenv() is run it will overwrite WAVY_CONFIG for the
future. it does therefore not make sense to run it on a conditional or
dependent on what exists in something that is run multiple times.
Anyway, I think it makes sense to let `.env` override WAVY_CONFIG, and
fallback to WAVY_CONFIG if available. This way you get a hybrid where
you can depend on the current directory if you put a `.env` there.

I think this information should go in docs/config.rst with a description
+ spec of the yaml files.
