### PR TITLE
Collocation options + drop_duplicates

### DIFF
--- a/tests/test_collocmod.py
+++ b/tests/test_collocmod.py
@@ -26,8 +26,8 @@ def test_sat_collocation_and_validation(test_data, tmpdir):
     sco = sco.crop_to_region(model)
 
     # collocate
-    cco = cc(oco=sco, model=model, leadtime='best', distlim=6)
-    assert len(vars(cco).keys()) == 15
+    cco = cc(oco=sco, model=model, leadtime='best', distlim=6).populate()
+    assert len(vars(cco).keys()) == 16
     assert len(cco.vars.keys()) == 9
 
     # validate
@@ -50,8 +50,8 @@ def test_insitu_collocation_and_validation(test_data, tmpdir):
     ico = ico.populate()
 
     # collocate
-    cco = cc(oco=ico, model=model, leadtime='best', distlim=6)
-    assert len(vars(cco).keys()) == 15
+    cco = cc(oco=ico, model=model, leadtime='best', distlim=6).populate()
+    assert len(vars(cco).keys()) == 16
     assert len(cco.vars.keys()) == 9
 
     # validate
@@ -68,8 +68,8 @@ def test_poi_collocation():
     pco = pc(poi_dict)
 
     # collocate
-    cco = cc(oco=pco, model='ww3_4km', leadtime='best')
-    assert len(vars(cco).keys()) == 15
+    cco = cc(oco=pco, model='ww3_4km', leadtime='best').populate()
+    assert len(vars(cco).keys()) == 16
     assert len(cco.vars.keys()) == 9
 
 

--- a/wavy/satellite_module.py
+++ b/wavy/satellite_module.py
@@ -588,6 +588,16 @@ class satellite_class(qls, wc, fc):
             print('# ----- ')
         return self
 
+    def drop_duplicates(self, dim='time', keep='first'):
+        print('Removing duplicates according to', dim)
+        print('Keeping', keep, 'value for the duplicates')
+        new = deepcopy(self)
+        new.vars = self.vars.drop_duplicates(dim=dim, keep=keep)
+        print(str(int(abs(len(self.vars[dim])-len(new.vars[dim])))),
+              'values removed')
+        print('New number of footprints is:', str(int(len(new.vars[dim]))))
+        return new
+
     def _match_poi(self, poi):
         """
         return: idx that match to region


### PR DESCRIPTION
- Added alternative method for the collocation of the model, in collocation_module, the object has to be populated now to launch the collocation with the method chosen at initialization. 
- Added method to drop duplicates in the collocation module, the method is applied by default right after the collocation is done. User can chose dimension and which duplicate to keep. 
- Added option to chose which duplicate to keep in drop_duplicates method for the satellite_module